### PR TITLE
Remove pretty-printing from JSON.stringify in logs

### DIFF
--- a/api/foursquareV3.ts
+++ b/api/foursquareV3.ts
@@ -45,7 +45,7 @@ class ReactNativeHTTPClient {
 
     console.log('🌐 Making request to:', url);
     console.log(
-      `%c this.headersr ` + JSON.stringify(this.headers, null, 4),
+      `%c this.headersr ` + JSON.stringify(this.headers),
       'color:white; background:green; font-size: 20px'
     );
     console.log('🔑 Authorization header:', this.headers.Authorization ? 'Present' : 'Missing');

--- a/components/screens/AlertsScreen/index.tsx
+++ b/components/screens/AlertsScreen/index.tsx
@@ -110,7 +110,7 @@ export function AlertsScreen() {
       }
     }
   };
-  console.log('🔍 Bucket list items:', JSON.stringify(bucketListItems, null, 2));
+  console.log('🔍 Bucket list items:', JSON.stringify(bucketListItems));
 
   const restaurantsWithLocation = bucketListItems.filter((item: BucketListItem) => {
     return (

--- a/components/screens/DetailScreen/index.tsx
+++ b/components/screens/DetailScreen/index.tsx
@@ -328,7 +328,7 @@ export const DetailScreen: React.FC = () => {
 
     if (!isVenueSaved) {
       const venueToSave = { ...venueDetails, iconUrl };
-      console.log('🗺️ venueToSave🗺️🗺️', JSON.stringify(venueToSave, null, 4));
+      console.log('🗺️ venueToSave🗺️🗺️', JSON.stringify(venueToSave));
 
       dispatch(addToBucketList(venueToSave) as any);
       Alert.alert('Saved', `${venueName} has been added to your bucket list!`);

--- a/services/GeofencingService.ts
+++ b/services/GeofencingService.ts
@@ -45,7 +45,7 @@ TaskManager.defineTask(
           : eventType;
       console.log(
         `[GeofencingService] Geofence event: ${eventTypeStr} | Region:`,
-        JSON.stringify(region, null, 2)
+        JSON.stringify(region)
       );
       if (eventType === Location.GeofencingEventType.Enter) {
         console.log('[GeofencingService] ENTER event triggered for region:', region.identifier);
@@ -106,7 +106,7 @@ class GeofencingService {
   async addGeofence(geofence: Geofence): Promise<void> {
     this.geofences.push(geofence);
     console.log('[GeofencingService] Geofence added:', geofence);
-    console.log('[GeofencingService] All geofences:', JSON.stringify(this.geofences, null, 2));
+    console.log('[GeofencingService] All geofences:', JSON.stringify(this.geofences));
     await this._saveGeofences();
     await this._updateGeofences();
   }
@@ -114,7 +114,7 @@ class GeofencingService {
   async removeGeofence(id: string): Promise<void> {
     this.geofences = this.geofences.filter(g => g.id !== id);
     console.log('[GeofencingService] Geofence removed:', id);
-    console.log('[GeofencingService] All geofences:', JSON.stringify(this.geofences, null, 2));
+    console.log('[GeofencingService] All geofences:', JSON.stringify(this.geofences));
     await this._saveGeofences();
     await this._updateGeofences();
   }
@@ -186,7 +186,7 @@ class GeofencingService {
 
   // Debug method to log all geofences
   logAllGeofences() {
-    console.log('[GeofencingService] Current geofences:', JSON.stringify(this.geofences, null, 2));
+    console.log('[GeofencingService] Current geofences:', JSON.stringify(this.geofences));
   }
 
   // Initialize the service

--- a/store/index.ts
+++ b/store/index.ts
@@ -94,5 +94,5 @@ if (__DEV__) {
 
   // Log initial state
   console.log('🏪 Redux Store initialized with Supabase middleware');
-  console.log('📊 Initial State:', JSON.stringify(store.getState(), null, 4));
+  console.log('📊 Initial State:', JSON.stringify(store.getState()));
 }

--- a/store/reducers/bucketList.ts
+++ b/store/reducers/bucketList.ts
@@ -122,11 +122,11 @@ export const fetchBucketList = createAsyncThunk('bucketList/fetch', async (_, { 
   console.log('Current user ID:', userId);
 
   const items = state.bucketList.items;
-  console.log('Current items in state:', JSON.stringify(items, null, 4));
+  console.log('Current items in state:', JSON.stringify(items));
 
   // Enhance items with venue details if needed
   const enhancedItems = await enhanceBucketListWithVenueDetails(items);
-  console.log('Enhanced items with venue details:', JSON.stringify(enhancedItems, null, 4));
+  console.log('Enhanced items with venue details:', JSON.stringify(enhancedItems));
 
   return enhancedItems;
 });

--- a/store/sagas/bucketListSaga.ts
+++ b/store/sagas/bucketListSaga.ts
@@ -62,7 +62,7 @@ function* handleFetchBucketList(): Generator<any, void, any> {
 
     // Enhance items with venue details if needed
     const enhancedItems = yield call(enhanceBucketListWithVenueDetails, items);
-    console.log('Enhanced items with venue details:', JSON.stringify(enhancedItems, null, 4));
+    console.log('Enhanced items with venue details:', JSON.stringify(enhancedItems));
 
     // Handle success
     yield put(fetchBucketListSuccess(enhancedItems));

--- a/store/slices/bucketListSlice.ts
+++ b/store/slices/bucketListSlice.ts
@@ -121,11 +121,11 @@ export const fetchBucketList = createAsyncThunk('bucketList/fetch', async (_, { 
   // Since we're using redux-persist, the items are already in state
   // We just need to enhance them with venue details if needed
   const items = state.bucketList.items;
-  console.log('Current items in state:', JSON.stringify(items, null, 4));
+  console.log('Current items in state:', JSON.stringify(items));
 
   // Enhance items with venue details if needed
   const enhancedItems = await enhanceBucketListWithVenueDetails(items);
-  console.log('Enhanced items with venue details:', JSON.stringify(enhancedItems, null, 4));
+  console.log('Enhanced items with venue details:', JSON.stringify(enhancedItems));
 
   return enhancedItems;
 });

--- a/store/slices/venuesSlice.ts
+++ b/store/slices/venuesSlice.ts
@@ -87,7 +87,7 @@ const venuesSlice = createSlice({
     },
     fetchNearbyVenuesSuccess(state, action: PayloadAction<Venue[]>) {
       console.log(
-        `%c action.payload fetchNearbyVenuesSuccess ${JSON.stringify(action.payload, null, 4)}`,
+        `%c action.payload fetchNearbyVenuesSuccess ${JSON.stringify(action.payload)}`,
         'color:white; background:green; font-size: 20px'
       );
       state.nearby.venues = action.payload;
@@ -98,7 +98,7 @@ const venuesSlice = createSlice({
       state.nearby.loading = false;
       state.nearby.error = action.payload;
       console.log(
-        `%c action.payload fetchNearbyVenuesFailure ${JSON.stringify(action.payload, null, 4)}`,
+        `%c action.payload fetchNearbyVenuesFailure ${JSON.stringify(action.payload)}`,
         'color:white; background:green; font-size: 20px'
       );
     },
@@ -161,7 +161,7 @@ const venuesSlice = createSlice({
       // The actual selection logic is handled in the setSelectedVenue reducer
       state.selectedVenue = null; // Reset selected venue before setting a new one
       console.log(
-        `%c action.payload selectVenue ${JSON.stringify(_action.payload, null, 4)}`,
+        `%c action.payload selectVenue ${JSON.stringify(_action.payload)}`,
         'color:white; background:green; font-size: 20px'
       );
       // Note: The actual selection logic is handled in the setSelectedVenue reducer
@@ -177,7 +177,7 @@ const venuesSlice = createSlice({
     fetchFoursquareDataSuccess(state, action: PayloadAction<string>) {
       state.foursquareData.rawJson = action.payload;
       console.log(
-        `%c action.payload fetchFoursquareDataSuccess ${JSON.stringify(action.payload, null, 4)}`,
+        `%c action.payload fetchFoursquareDataSuccess ${JSON.stringify(action.payload)}`,
         'color:white; background:green; font-size: 20px'
       );
       state.foursquareData.loading = false;
@@ -186,7 +186,7 @@ const venuesSlice = createSlice({
     fetchFoursquareDataFailure(state, action: PayloadAction<string>) {
       state.foursquareData.loading = false;
       console.log(
-        `%c action.payload fetchFoursquareDataFailure ${JSON.stringify(action.payload, null, 4)}`,
+        `%c action.payload fetchFoursquareDataFailure ${JSON.stringify(action.payload)}`,
         'color:white; background:green; font-size: 20px'
       );
       state.foursquareData.error = action.payload;

--- a/utils/deepLinkUtils.ts
+++ b/utils/deepLinkUtils.ts
@@ -45,7 +45,7 @@ export function parseVenueDeepLink(url: string): { venueId: string; autoSave: bo
 
     const pathPart = url.replace('dinnafind://restaurant/', '');
     const [venueId, ...rest] = pathPart.split('/');
-    console.log('venueId ', JSON.stringify({ venueId, rest }, null, 2));
+    console.log('venueId ', JSON.stringify({ venueId, rest }));
 
     if (!venueId) {
       return null;
@@ -55,7 +55,7 @@ export function parseVenueDeepLink(url: string): { venueId: string; autoSave: bo
     const queryStart = venueId.indexOf('?');
     let actualVenueId = venueId;
     let autoSave = false;
-    console.log('queryStart  ', JSON.stringify({ queryStart }, null, 2));
+    console.log('queryStart  ', JSON.stringify({ queryStart }));
     if (queryStart > -1) {
       actualVenueId = venueId.substring(0, queryStart);
       const queryString = venueId.substring(queryStart + 1);


### PR DESCRIPTION
Replaces all uses of JSON.stringify with pretty-printing (using null and spacing arguments) in console.log statements with the default compact output. This change reduces log verbosity and improves readability in development logs across multiple files.